### PR TITLE
feat: orchestrator runners + tool safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
+.env.example
+
 *.py[codz]
 *$py.class
 
@@ -209,3 +211,4 @@ __marimo__/
 key
 .DS_Store
 .DS_Store
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,17 +8,31 @@ services:
       POSTGRES_DB: app
     ports: ["5434:5432"]
 
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama:/root/.ollama
+    restart: unless-stopped
+
   mcp-sandbox:
     build: ./services/mcp-sandbox
     ports: ["7001:7001"]
+    volumes:
+      - ./sandbox:/sandbox
 
   gateway-api:
     build: ./services/gateway-api
     environment:
+      OPENAI_API_KEY: ollama
+      OPENAI_API_BASE: http://ollama:11434/v1
+      OPENAI_MODEL_NAME: llama3.1:8b
+      GATEWAY_GRAPHQL_URL: http://gateway-api:8000/graphql
       DATABASE_URL: postgresql+psycopg2://app:app@postgres:5432/app
       MCP_URL: http://mcp-sandbox:7001
     ports: ["8000:8000"]
-    depends_on: [postgres, mcp-sandbox]
+    depends_on: [postgres, mcp-sandbox, ollama]
 
   prometheus:
     image: prom/prometheus
@@ -26,3 +40,6 @@ services:
       - ./infra/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
     ports: ["9090:9090"]
     depends_on: [gateway-api]
+
+volumes:
+  ollama:

--- a/sandbox/example.txt
+++ b/sandbox/example.txt
@@ -1,0 +1,1 @@
+Hello from /sandbox

--- a/services/gateway-api/app/agents/crewai_runner.py
+++ b/services/gateway-api/app/agents/crewai_runner.py
@@ -1,0 +1,120 @@
+import re
+
+from crewai import Agent, Task, Crew, Process
+from .crewai_tools import FSListDirTool, FSReadFileTool, propose_tool_call
+from app.llm import get_crewai_llm  # <-- add this
+
+
+def _extract_path(task: str) -> str | None:
+    match = re.search(r'(/[^\s"\']+)', task)
+    return match.group(1) if match else None
+
+
+def _select_tool(task: str) -> tuple[str, dict] | None:
+    task_l = task.lower()
+
+    if any(word in task_l for word in ("list", "show", "display")) and any(
+        word in task_l for word in ("file", "files", "dir", "directory", "folder")
+    ):
+        return "fs.list_dir", {"path": _extract_path(task) or "/sandbox"}
+
+    path = _extract_path(task)
+    if "read" in task_l and ("file" in task_l or path):
+        return "fs.read_file", {"path": path or "/sandbox/example.txt"}
+
+    return None
+
+
+def run_crewai(task: str) -> dict:
+    forced = _select_tool(task)
+    if forced:
+        tool, args = forced
+        tool_result = propose_tool_call(tool, args, "investigator")
+        if tool_result.startswith("[BLOCKED]"):
+            rendered = (
+                f"Tool Output: {tool_result}\n"
+                "I can't perform that action due to policy restrictions."
+            )
+            return {"orchestrator": "crewai", "task": task, "result": rendered}
+
+        if tool == "fs.list_dir":
+            rendered = f"Tool Output: {tool_result}\nFound files in {args['path']}."
+        elif tool == "fs.read_file":
+            rendered = f"Tool Output: {tool_result}\nRead file {args['path']}."
+        else:
+            rendered = f"Tool Output: {tool_result}"
+
+        return {"orchestrator": "crewai", "task": task, "result": rendered}
+
+    llm = get_crewai_llm()
+
+    planner = Agent(
+        role="Planner",
+        goal="Decompose the user request into concrete investigation steps.",
+        backstory="You plan safe, minimal actions and avoid unnecessary tool use.",
+        llm=llm,
+        verbose=False,
+        allow_delegation=False,
+    )
+
+    investigator = Agent(
+        role="Investigator",
+        goal="Gather evidence using only safe, governed tools.",
+        backstory="You only use the provided tools and you respect BLOCKED results.",
+        tools=[FSListDirTool("investigator"), FSReadFileTool("investigator")],
+        llm=llm,
+        verbose=False,
+        allow_delegation=False,
+    )
+
+    auditor = Agent(
+        role="Auditor",
+        goal="Check outputs for safety issues and summarize what happened.",
+        backstory="You flag policy blocks and suspicious results.",
+        llm=llm,
+        verbose=False,
+        allow_delegation=False,
+    )
+
+    t1 = Task(
+        description=f"Create a short plan for: {task}. If tools are needed, say which.",
+        expected_output="A 1-3 step plan.",
+        agent=planner,
+    )
+
+    t2 = Task(
+        description=(
+            f"User request: {task}\n\n"
+            "RULES:\n"
+            "- If the user request includes the word 'list', you MUST call the tool `fs_list_dir` exactly once with path \"/sandbox\".\n"
+            "- If the user request includes the word 'read' and includes a path, you MUST call the tool `fs_read_file` exactly once with that path.\n"
+            "- Return the raw tool output string EXACTLY as received.\n"
+            "- If the tool returns a string starting with \"[BLOCKED]\", return that string and STOP.\n"
+            "- Do not invent steps or errors.\n"
+        ),
+        expected_output="Raw tool output (or [BLOCKED] reason) and nothing else.",
+        agent=investigator,
+    )
+
+    t3 = Task(
+        description=(
+            "Produce a final answer for the user.\n"
+            "You MUST include a line:\n"
+            "Tool Output: <...>\n"
+            "Where <...> is the EXACT output string from step 2 (e.g., [] or [BLOCKED] ...).\n"
+            "Do NOT invent filesystem errors like 'directory does not exist'.\n"
+        ),
+        expected_output="A short final answer plus the required Tool Output line.",
+        agent=auditor,
+    )
+
+    crew = Crew(
+        agents=[planner, investigator, auditor],
+        tasks=[t1, t2, t3],
+        process=Process.sequential,
+        verbose=False,
+    )
+
+    result = crew.kickoff()
+
+    return {"orchestrator": "crewai", "task": task, "result": str(result)}

--- a/services/gateway-api/app/agents/crewai_tools.py
+++ b/services/gateway-api/app/agents/crewai_tools.py
@@ -1,0 +1,112 @@
+import os
+import requests
+from typing import Type
+from pydantic import BaseModel, Field
+from crewai.tools import BaseTool
+
+DEFAULT_GQL = "http://localhost:8000/graphql"
+GATEWAY_GRAPHQL_URL = os.getenv("GATEWAY_GRAPHQL_URL", DEFAULT_GQL)
+
+PROPOSE_MUTATION = """
+mutation Propose($tool: String!, $args: JSON!) {
+  proposeToolCall(tool: $tool, args: $args) {
+    decision
+    reason
+    result
+  }
+}
+"""
+
+def _normalize_sandbox_path(path: str) -> str | None:
+    """
+    Enforce that all filesystem paths are under /sandbox.
+    - If a relative path is provided, it is treated as relative to /sandbox.
+    - If an absolute path outside /sandbox is provided, block it early.
+    Returns the normalized absolute path, or None if blocked.
+    """
+    if not path:
+        return "/sandbox"
+
+    p = path.strip()
+
+    # Treat relative paths as under /sandbox
+    if not p.startswith("/"):
+        p = f"/sandbox/{p}"
+
+    # Collapse accidental double slashes
+    while "//" in p:
+        p = p.replace("//", "/")
+
+    # Enforce sandbox boundary
+    if p == "/sandbox" or p.startswith("/sandbox/"):
+        return p
+
+    return None
+
+def _propose(tool: str, args: dict, agent_role: str) -> str:
+    # (Optional) include agent role in args for now; later we’ll store it in DB columns
+    args = {**args, "__agent_role": agent_role, "__orchestrator": "crewai"}
+
+    payload = {"query": PROPOSE_MUTATION, "variables": {"tool": tool, "args": args}}
+    r = requests.post(GATEWAY_GRAPHQL_URL, json=payload, timeout=10)
+    r.raise_for_status()
+    data = r.json()["data"]["proposeToolCall"]
+
+    if data["decision"] != "ALLOW":
+        return f"[BLOCKED] {data['reason']}"
+
+    return data["result"] or ""
+
+
+def propose_tool_call(tool: str, args: dict, agent_role: str) -> str:
+    """
+    Public wrapper for deterministic tool execution (bypasses LLM hallucinations).
+    """
+    # Enforce sandbox boundary for filesystem tools
+    if tool in ("fs.list_dir", "fs.read_file"):
+        norm = _normalize_sandbox_path(str(args.get("path", "")))
+        if norm is None:
+            return "[BLOCKED] path must be under /sandbox"
+        args = {**args, "path": norm}
+
+    return _propose(tool, args, agent_role)
+
+
+class ListDirInput(BaseModel):
+    path: str = Field(..., description="Directory path to list")
+
+
+class FSListDirTool(BaseTool):
+    name: str = "fs_list_dir"
+    description: str = "List files in a sandbox directory (governed by Senteniel policy)."
+    args_schema: Type[BaseModel] = ListDirInput
+
+    def __init__(self, agent_role: str):
+        super().__init__()
+        self._agent_role = agent_role
+
+    def _run(self, path: str) -> str:
+        norm = _normalize_sandbox_path(path)
+        if norm is None:
+            return "[BLOCKED] path must be under /sandbox"
+        return _propose("fs.list_dir", {"path": norm}, self._agent_role)
+
+
+class ReadFileInput(BaseModel):
+    path: str = Field(..., description="File path to read")
+
+
+class FSReadFileTool(BaseTool):
+    name: str = "fs_read_file"
+    description: str = "Read a file from the sandbox (governed by Senteniel policy)."
+    args_schema: Type[BaseModel] = ReadFileInput
+
+    def __init__(self, agent_role: str):
+        super().__init__()
+        self._agent_role = agent_role
+
+    def _run(self, path: str) -> str:
+        norm = _normalize_sandbox_path(path)
+        if norm is None:
+            return "[BLOCKED] path must be under /sandbox"
+        return _propose("fs.read_file", {"path": norm}, self._agent_role)

--- a/services/gateway-api/app/agents/fsm_runner.py
+++ b/services/gateway-api/app/agents/fsm_runner.py
@@ -1,72 +1,230 @@
+import os
+import re
 import requests
+
 from .fsm_types import FSMState, FSMContext
 
-GATEWAY_GRAPHQL_URL = "http://localhost:8000/graphql"
+# Use env override so this works both inside Docker and on host.
+GATEWAY_GRAPHQL_URL = os.getenv("GATEWAY_GRAPHQL_URL", "http://localhost:8000/graphql")
+
+PROPOSE_MUTATION = """
+mutation Propose($tool: String!, $args: JSON!) {
+  proposeToolCall(tool: $tool, args: $args) {
+    decision
+    reason
+    result
+  }
+}
+"""
 
 
-class FSMRunner:
-    def __init__(self, task: str):
+def _extract_path(text: str) -> str | None:
+    """Extract an absolute path from free-form text, stopping at whitespace/quotes."""
+    if not text:
+        return None
+    m = re.search(r'(/[^\s"\']+)', text)
+    return m.group(1) if m else None
+
+
+def _normalize_sandbox_path(path: str | None) -> str | None:
+    """
+    Enforce that all filesystem paths are under /sandbox.
+    - Relative paths become /sandbox/<path>
+    - Absolute paths outside /sandbox are blocked.
+    Returns normalized absolute path, or None if blocked.
+    """
+    if not path:
+        return "/sandbox"
+
+    p = path.strip()
+
+    # Treat relative paths as under /sandbox
+    if not p.startswith("/"):
+        p = f"/sandbox/{p}"
+
+    # Collapse accidental double slashes
+    while "//" in p:
+        p = p.replace("//", "/")
+
+    # Enforce sandbox boundary
+    if p == "/sandbox" or p.startswith("/sandbox/"):
+        return p
+
+    return None
+
+
+class HybridFSM:
+    """
+    Hybrid FSM orchestrator:
+    - Multi-role phases: planner -> investigator -> auditor
+    - Deterministic control-flow (no LLM decides whether tools run)
+    - All tool execution is governed via Senteniel GraphQL -> MCP.
+    """
+
+    def __init__(self, user_task: str):
+        self.ctx = FSMContext(user_task=user_task)
+        # Distinguish hybrid in logs/leaderboard
+        self.ctx.orchestrator = "fsm_hybrid"
         self.state = FSMState.INIT
-        self.ctx = FSMContext(user_task=task)
 
-    def run(self) -> FSMContext:
-        while self.state != FSMState.DONE:
+    def run(self) -> dict:
+        while self.state not in (FSMState.DONE,):
             if self.state == FSMState.INIT:
                 self.state = FSMState.PLAN
 
             elif self.state == FSMState.PLAN:
                 self._plan()
-                self.state = FSMState.PROPOSE_TOOL
 
             elif self.state == FSMState.PROPOSE_TOOL:
                 self._propose_tool()
 
             elif self.state in (FSMState.BLOCKED, FSMState.EXECUTED):
+                self._audit()
+
+            else:
                 self.state = FSMState.DONE
 
-        return self.ctx
-
-    def _plan(self):
-        task = self.ctx.user_task.lower()
-
-        if "list" in task:
-            self.ctx.plan = "List sandbox files"
-            self.ctx.tool = "fs.list_dir"
-            self.ctx.args = {"path": "/sandbox"}
-        elif "read" in task:
-            self.ctx.plan = "Read sandbox file"
-            self.ctx.tool = "fs.read_file"
-            self.ctx.args = {"path": "/sandbox/example.txt"}
-        else:
-            self.ctx.plan = "No tool required"
-            self.state = FSMState.DONE
-
-    def _propose_tool(self):
-        query = {
-            "query": """
-            mutation Propose($tool: String!, $args: JSON!) {
-              proposeToolCall(tool: $tool, args: $args) {
-                decision
-                reason
-                result
-              }
-            }
-            """,
-            "variables": {
+        return {
+            "final_state": {
+                "orchestrator": self.ctx.orchestrator,
+                "agent_role": self.ctx.agent_role,
+                "user_task": self.ctx.user_task,
+                "requested_path": self.ctx.requested_path,
+                "normalized_path": self.ctx.normalized_path,
+                "plan": self.ctx.plan,
                 "tool": self.ctx.tool,
                 "args": self.ctx.args,
+                "decision": self.ctx.decision,
+                "result": self.ctx.result,
             },
+            "final_answer": getattr(self.ctx, "final_answer", None),
         }
 
-        resp = requests.post(GATEWAY_GRAPHQL_URL, json=query, timeout=5)
-        resp.raise_for_status()
+    # ---- Role: Planner ----
+    def _plan(self) -> None:
+        self.ctx.agent_role = "planner"
+        task_l = (self.ctx.user_task or "").lower()
 
+        # LIST
+        if "list" in task_l:
+            self.ctx.plan = "List sandbox files"
+            self.ctx.tool = "fs.list_dir"
+            self.ctx.requested_path = "/sandbox"
+            self.ctx.normalized_path = "/sandbox"
+            self.ctx.args = {
+                "path": "/sandbox",
+                "__orchestrator": self.ctx.orchestrator,
+                "__agent_role": self.ctx.agent_role,
+            }
+            self.state = FSMState.PROPOSE_TOOL
+            return
+
+        # READ
+        if "read" in task_l:
+            requested = _extract_path(self.ctx.user_task) or "/sandbox/example.txt"
+            norm = _normalize_sandbox_path(requested)
+
+            self.ctx.requested_path = requested
+            self.ctx.normalized_path = norm
+            self.ctx.plan = f"Read file {requested}"
+            self.ctx.tool = "fs.read_file"
+
+            # If the user explicitly requested an out-of-sandbox path, block deterministically.
+            if _extract_path(self.ctx.user_task) is not None and norm is None:
+                self.ctx.decision = "BLOCK"
+                self.ctx.result = "[BLOCKED] path must be under /sandbox"
+                self.state = FSMState.BLOCKED
+                return
+
+            # Otherwise, use normalized (or safe default)
+            safe_path = norm or "/sandbox/example.txt"
+            self.ctx.args = {
+                "path": safe_path,
+                "__orchestrator": self.ctx.orchestrator,
+                "__agent_role": self.ctx.agent_role,
+            }
+            self.state = FSMState.PROPOSE_TOOL
+            return
+
+        # NO TOOL
+        self.ctx.plan = "No tool required"
+        self.ctx.decision = "ALLOW"
+        self.ctx.result = ""
+        self.state = FSMState.DONE
+
+    # ---- Role: Investigator ----
+    def _propose_tool(self) -> None:
+        self.ctx.agent_role = "investigator"
+
+        if not self.ctx.tool:
+            self.state = FSMState.DONE
+            return
+
+        # Enforce sandbox boundary for filesystem tools
+        if self.ctx.tool in ("fs.list_dir", "fs.read_file"):
+            raw = None
+            if isinstance(self.ctx.args, dict):
+                raw = self.ctx.args.get("path")
+
+            norm = _normalize_sandbox_path(raw)
+
+            # If the user explicitly requested a path and it's outside sandbox, block.
+            if self.ctx.requested_path and _extract_path(self.ctx.user_task) is not None and norm is None:
+                self.ctx.decision = "BLOCK"
+                self.ctx.result = "[BLOCKED] path must be under /sandbox"
+                self.state = FSMState.BLOCKED
+                return
+
+            if norm is None:
+                self.ctx.decision = "BLOCK"
+                self.ctx.result = "[BLOCKED] path must be under /sandbox"
+                self.state = FSMState.BLOCKED
+                return
+
+            self.ctx.args = {
+                **(self.ctx.args or {}),
+                "path": norm,
+                "__orchestrator": self.ctx.orchestrator,
+                "__agent_role": self.ctx.agent_role,
+            }
+
+        payload = {
+            "query": PROPOSE_MUTATION,
+            "variables": {"tool": self.ctx.tool, "args": self.ctx.args or {}},
+        }
+
+        resp = requests.post(GATEWAY_GRAPHQL_URL, json=payload, timeout=10)
+        resp.raise_for_status()
         data = resp.json()["data"]["proposeToolCall"]
-        self.ctx.decision = data["decision"]
 
         if data["decision"] != "ALLOW":
-            self.ctx.result = data["reason"]
+            self.ctx.decision = "BLOCK"
+            self.ctx.result = f"[BLOCKED] {data['reason']}"
             self.state = FSMState.BLOCKED
+            return
+
+        self.ctx.decision = "ALLOW"
+        self.ctx.result = data.get("result")
+        self.state = FSMState.EXECUTED
+
+    # ---- Role: Auditor ----
+    def _audit(self) -> None:
+        self.ctx.agent_role = "auditor"
+
+        # Deterministic, audit-friendly formatting.
+        if isinstance(self.ctx.result, str) and (
+            self.ctx.result.startswith("[BLOCKED]") or self.ctx.result.startswith("[ERROR]")
+        ):
+            self.ctx.final_answer = (
+                f"Tool Output: {self.ctx.result}\n"
+                "I can’t perform that action due to policy restrictions."
+            )
         else:
-            self.ctx.result = data["result"]
-            self.state = FSMState.EXECUTED
+            self.ctx.final_answer = f"Tool Output: {self.ctx.result}\nCompleted."
+
+        self.state = FSMState.DONE
+
+
+def run_fsm(user_task: str) -> dict:
+    """Entrypoint used by the API layer."""
+    return HybridFSM(user_task).run()

--- a/services/gateway-api/app/agents/fsm_types.py
+++ b/services/gateway-api/app/agents/fsm_types.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 
@@ -15,6 +15,12 @@ class FSMState(str, Enum):
 @dataclass
 class FSMContext:
     user_task: str
+    orchestrator: str = "fsm"
+    agent_role: str = "single"
+    requested_path: Optional[str] = None
+    normalized_path: Optional[str] = None
+    final_answer: Optional[str] = None
+
     plan: Optional[str] = None
     tool: Optional[str] = None
     args: Optional[dict] = None

--- a/services/gateway-api/app/llm.py
+++ b/services/gateway-api/app/llm.py
@@ -1,0 +1,52 @@
+# services/gateway-api/app/llm.py
+import os
+from functools import lru_cache
+
+from crewai import LLM
+from langchain_ollama import ChatOllama
+
+
+def _env(name: str, default: str) -> str:
+    v = os.getenv(name)
+    return v if v else default
+
+
+@lru_cache(maxsize=1)
+def get_crewai_llm() -> LLM:
+    """
+    CrewAI LLM configured to talk to Ollama via Ollama's OpenAI-compatible endpoint (/v1).
+    This avoids OpenAI subscriptions; OPENAI_API_KEY is a dummy value to satisfy CrewAI's checks.
+    """
+    # Prefer explicit OpenAI-compatible envs (best for CrewAI)
+    api_base = _env("OPENAI_API_BASE", "")
+
+    # Fallback: derive OpenAI-compatible base from OLLAMA_BASE_URL
+    if not api_base:
+        ollama_base = _env("OLLAMA_BASE_URL", "http://localhost:11434").rstrip("/")
+        api_base = f"{ollama_base}/v1"
+
+    model = _env("OPENAI_MODEL_NAME", _env("OLLAMA_MODEL", "llama3.1:8b"))
+    api_key = _env("OPENAI_API_KEY", "ollama")  # dummy, used only to satisfy validation
+
+    return LLM(
+        model=f"openai/{model}",
+        base_url=api_base,
+        api_key=api_key,
+        temperature=0.0,
+    )
+
+@lru_cache(maxsize=1)
+def get_langchain_chat_llm() -> ChatOllama:
+    """
+    LangChain Chat model configured for Ollama.
+    """
+    base_url = _env("OLLAMA_BASE_URL", "http://localhost:11434")
+    model = _env("OLLAMA_MODEL", "llama3.1:8b")
+
+    # LangChain Ollama chat uses ChatOllama from the langchain-ollama package  [oai_citation:3‡docs.langchain.com](https://docs.langchain.com/oss/python/integrations/chat/ollama)
+    # base_url is supported as an init arg in langchain_ollama.  [oai_citation:4‡reference.langchain.com](https://reference.langchain.com/python/integrations/langchain_ollama/)
+    return ChatOllama(
+        model=model,
+        base_url=base_url,
+        temperature=0,
+    )

--- a/services/gateway-api/app/main.py
+++ b/services/gateway-api/app/main.py
@@ -6,7 +6,10 @@ from .db.base import Base
 from .db.session import engine
 from .agents.langgraph_runner import build_langgraph
 from .agents.state import AgentState
-from .agents.fsm_runner import FSMRunner
+from .agents.fsm_runner import HybridFSM
+
+
+from .agents.crewai_runner import run_crewai
 
 
 
@@ -42,8 +45,10 @@ def run_agent(task: str):
 
 @app.post("/agent/fsm/run")
 def run_fsm(task: str):
-    fsm = FSMRunner(task)
+    fsm = HybridFSM(task)
     ctx = fsm.run()
-    return {
-        "final_state": ctx,
-    }
+    return ctx
+
+@app.post("/agent/crew/run")
+def run_crew(task: str):
+    return run_crewai(task)

--- a/services/gateway-api/requirements.txt
+++ b/services/gateway-api/requirements.txt
@@ -2,9 +2,15 @@ fastapi
 strawberry-graphql
 uvicorn
 pydantic
+email-validator
 sqlalchemy
 psycopg2-binary
 prometheus-client
 requests
 langgraph
 langchain-core
+crewai
+langchain-ollama
+litellm
+apscheduler
+fastapi-sso

--- a/services/mcp-sandbox/app/sandbox.py
+++ b/services/mcp-sandbox/app/sandbox.py
@@ -5,14 +5,17 @@ SANDBOX_ROOT.mkdir(parents=True, exist_ok=True)
 
 def validate_path(path: str) -> Path:
     sandbox_root_str = str(SANDBOX_ROOT)
-    if path == sandbox_root_str or path.startswith(sandbox_root_str + "/"):
-        rel = path[len(sandbox_root_str):].lstrip("/")
-        candidate = (SANDBOX_ROOT / rel).resolve()
+    if path.startswith("/"):
+        if path == sandbox_root_str or path.startswith(sandbox_root_str + "/"):
+            rel = path[len(sandbox_root_str):].lstrip("/")
+            candidate = (SANDBOX_ROOT / rel).resolve()
+        else:
+            raise ValueError("path must be under /sandbox")
     else:
-        candidate = (SANDBOX_ROOT / path.lstrip("/")).resolve()
+        candidate = (SANDBOX_ROOT / path).resolve()
 
     if not str(candidate).startswith(sandbox_root_str):
-        raise ValueError("Path escapes sandbox")
+        raise ValueError("path must be under /sandbox")
 
     return candidate
 


### PR DESCRIPTION
Add CrewAI runner/tools, LangGraph runner, and hybrid FSM baseline. Enforce /sandbox boundary, deterministic BLOCKED output, and consistent Tool Output formatting. Wire Ollama LLM adapter and update compose/env/examples.