### PR TITLE
Graph rag/new4j

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ Senteniel runs the **same governed tool calls** through three orchestration stra
   "tool_decision": {
     "tool_call_id": "<uuid>",
     "decision": "ALLOW",
-    "reason": "ok",
+    "reason": "Directory listing allowed",
     "result": "[\"example.txt\"]",
-    "policy_citations": [],
+    "policy_citations": ["P-SANDBOX-ALLOWLIST-001"],
     "incident_refs": [],
-    "control_refs": []
+    "control_refs": ["C-SANDBOX-BOUNDARY"]
   }
 }
 ```
@@ -145,11 +145,11 @@ Senteniel runs the **same governed tool calls** through three orchestration stra
   "tool_decision": {
     "tool_call_id": "<uuid>",
     "decision": "ALLOW",
-    "reason": "ok",
+    "reason": "Directory listing allowed",
     "result": "[\"example.txt\"]",
-    "policy_citations": [],
+    "policy_citations": ["P-SANDBOX-ALLOWLIST-001"],
     "incident_refs": [],
-    "control_refs": []
+    "control_refs": ["C-SANDBOX-BOUNDARY"]
   }
 }
 ```
@@ -166,9 +166,9 @@ Senteniel runs the **same governed tool calls** through three orchestration stra
     "decision": "BLOCK",
     "reason": "path must be under /sandbox",
     "result": null,
-    "policy_citations": [],
-    "incident_refs": [],
-    "control_refs": []
+    "policy_citations": ["P-SANDBOX-001"],
+    "incident_refs": ["I-EXFIL-001"],
+    "control_refs": ["C-SANDBOX-BOUNDARY"]
   }
 }
 ```
@@ -196,9 +196,9 @@ Senteniel runs the **same governed tool calls** through three orchestration stra
     "decision": "BLOCK",
     "reason": "path must be under /sandbox",
     "result": null,
-    "policy_citations": [],
-    "incident_refs": [],
-    "control_refs": []
+    "policy_citations": ["P-SANDBOX-001"],
+    "incident_refs": ["I-EXFIL-001"],
+    "control_refs": ["C-SANDBOX-BOUNDARY"]
   }
 }
 ```
@@ -212,6 +212,13 @@ Senteniel runs the **same governed tool calls** through three orchestration stra
   - policy citations
   - prior incident references
   - explicit reasoning paths
+
+**MVP status:**
+- Phase 2A implemented as **IDs‑only grounding (no LLM summarization)**
+- Currently wired IDs for sandbox boundary:
+  - `P-SANDBOX-001` (read outside sandbox → BLOCK)
+  - `P-SANDBOX-ALLOWLIST-001` (list_dir under sandbox → ALLOW)
+  - `C-SANDBOX-BOUNDARY`, `I-EXFIL-001`
 
 ---
 
@@ -424,9 +431,8 @@ Senteniel provides a web UI for **security, platform, and infra teams**:
 - ✅ Fairness rule enforced: same tools, same policies, same MCP boundary; only orchestrator differs
 
 ### 🚧 Phase 2 — GraphRAG Proof Mode
-- Neo4j policy graph
-- Incident grounding
-- Decision explanation graphs
+- Neo4j citations are working for both ALLOW and BLOCK
+- Next step: approval-required flow for write actions
 
 ### 🚧 Phase 3 — Evaluation Harness (next)
 - Task suite (`eval/tasks.jsonl`) covering utility + safety cases

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,8 +45,11 @@ services:
       GATEWAY_GRAPHQL_URL: http://gateway-api:8000/graphql
       DATABASE_URL: postgresql+psycopg2://app:app@postgres:5432/app
       MCP_URL: http://mcp-sandbox:7001
+      NEO4J_URI: bolt://neo4j:7687
+      NEO4J_USER: neo4j
+      NEO4J_PASSWORD: testpassword
     ports: ["8000:8000"]
-    depends_on: [postgres, mcp-sandbox, ollama]
+    depends_on: [postgres, mcp-sandbox, ollama, neo4j]
 
   prometheus:
     image: prom/prometheus

--- a/services/gateway-api/app/policy_graph.py
+++ b/services/gateway-api/app/policy_graph.py
@@ -1,12 +1,43 @@
 import os
 from neo4j import GraphDatabase
-
+import os
+from functools import lru_cache
 NEO4J_URI = os.getenv("NEO4J_URI", "bolt://neo4j:7687")
 NEO4J_USER = os.getenv("NEO4J_USER", "neo4j")
 NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD", "testpassword")
 
 _driver = None
 
+CYPHER_IDS = """
+MATCH (p:Policy)-[:REFERS_TO]->(t:ToolContract {tool_name:$tool})
+OPTIONAL MATCH (p)-[:ENFORCES]->(c:Control)
+OPTIONAL MATCH (i:Incident)-[:VIOLATED_BY]->(p)
+RETURN collect(DISTINCT p.id) AS policies,
+       collect(DISTINCT i.id) AS incidents,
+       collect(DISTINCT c.id) AS controls
+"""
+
+@lru_cache(maxsize=1)
+def _driver():
+    uri = os.getenv("NEO4J_URI")
+    if not uri:
+        return None
+    user = os.getenv("NEO4J_USER", "neo4j")
+    pwd = os.getenv("NEO4J_PASSWORD", "")
+    return GraphDatabase.driver(uri, auth=(user, pwd))
+
+def lookup_policy_ids(tool_name: str) -> tuple[list[str], list[str], list[str]]:
+    drv = _driver()
+    if not drv:
+        return [], [], []
+    with drv.session() as s:
+        rec = s.run(CYPHER_IDS, tool=tool_name).single()
+        if not rec:
+            return [], [], []
+        policies = [x for x in rec["policies"] if x]
+        incidents = [x for x in rec["incidents"] if x]
+        controls = [x for x in rec["controls"] if x]
+        return policies, incidents, controls
 def get_driver():
     global _driver
     if _driver is None:
@@ -56,3 +87,5 @@ def fetch_policy_context(tool_name: str, args: dict) -> dict:
         "control_refs": controls or [],
         "incident_refs": incident_ids or [],
     }
+
+

--- a/services/gateway-api/requirements.txt
+++ b/services/gateway-api/requirements.txt
@@ -15,3 +15,4 @@ litellm
 apscheduler
 fastapi-sso
 alembic>=1.12
+neo4j


### PR DESCRIPTION
What changed 
	•	Updated all JSON examples to include the actual populated arrays (Neo4j Policy Graph MVP):
	•	ALLOW now shows:
policy_citations: ["P-SANDBOX-ALLOWLIST-001"], control_refs: ["C-SANDBOX-BOUNDARY"]
	•	BLOCK now shows:
policy_citations: ["P-SANDBOX-001"], incident_refs: ["I-EXFIL-001"], control_refs: ["C-SANDBOX-BOUNDARY"]
	•	Added a short MVP status note under “GraphRAG-Backed Policy Reasoning”
	•	Updated the Roadmap Phase 2 bullets to reflect: “citations working for ALLOW + BLOCK” and “next: approval-required flow”